### PR TITLE
Move fatal to standard properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,11 @@ export class VFileMessage extends Error {
      */
     this.reason = this.message
     /**
+     * If true, marks associated file as no longer processable.
+     * @type {boolean?}
+     */
+    this.fatal
+    /**
      * Starting line of error.
      * @type {number?}
      */
@@ -110,11 +115,6 @@ export class VFileMessage extends Error {
      * @type {string?}
      */
     this.file
-    /**
-     * If true, marks associated file as no longer processable.
-     * @type {boolean?}
-     */
-    this.fatal
     /**
      * You may add a url property with a link to documentation for the message.
      * @type {string?}


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Move `fatal` from custom to to standard properties. This matches the readme.

<!--do not edit: pr-->
