### PR TITLE
Add well-known `actual`, `expected` fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,16 @@ export class VFileMessage extends Error {
 
     /* eslint-disable no-unused-expressions */
     /**
+     * You may use this to specify the actual value that’s being reported.
+     * @type {string?}
+     */
+    this.actual
+    /**
+     * You may use this to suggest expected values that should be used instead of `actual`.
+     * @type {string[]?}
+     */
+    this.expected
+    /**
      * You may add a file property with a path of a file (used throughout the VFile ecosystem).
      * @type {string?}
      */

--- a/index.js
+++ b/index.js
@@ -112,7 +112,8 @@ export class VFileMessage extends Error {
      */
     this.actual
     /**
-     * You may use this to suggest expected values that should be used instead of `actual`.
+     * You can use this to suggest values that should be used instead of
+     * `actual`, one or more values that are deemed as acceptable.
      * @type {Array<string>?}
      */
     this.expected

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ export class VFileMessage extends Error {
     this.actual
     /**
      * You may use this to suggest expected values that should be used instead of `actual`.
-     * @type {string[]?}
+     * @type {Array<string>?}
      */
     this.expected
     /**

--- a/index.js
+++ b/index.js
@@ -106,7 +106,8 @@ export class VFileMessage extends Error {
 
     /* eslint-disable no-unused-expressions */
     /**
-     * You may use this to specify the actual value that’s being reported.
+     * You can use this to specify the source value that’s being reported, which
+     * is deemed incorrect.
      * @type {string?}
      */
     this.actual

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,14 @@ Stack of message (`string?`).
 It’s OK to store custom data directly on the `VFileMessage`, some of those are
 handled by [utilities][util].
 
+###### `actual`
+
+You may use this to specify the actual value that’s being reported.
+
+###### `expected`
+
+You may use this to suggest expected values that should be used instead of `actual`.
+
 ###### `file`
 
 You may add a `file` property with a path of a file (used throughout the

--- a/readme.md
+++ b/readme.md
@@ -131,11 +131,13 @@ handled by [utilities][util].
 
 ###### `actual`
 
-You may use this to specify the actual value that’s being reported.
+You can use this to specify the source value that’s being reported, which is
+deemed incorrect.
 
 ###### `expected`
 
-You may use this to suggest expected values that should be used instead of `actual`.
+You can use this to suggest values that should be used instead of `actual`, one
+or more values that are deemed as acceptable.
 
 ###### `file`
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

These properties are used by various retext plugins.

<!--do not edit: pr-->
