### PR TITLE
Replace use of `null` with `undefined`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,7 @@ export class VFileMessage extends Error {
      * * `false` — necessitates a (potential) change (warning)
      * * `undefined` — for things that might not need changing (info)
      *
-     * @type {boolean | undefined}
+     * @type {boolean | null | undefined}
      */
     this.fatal
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,16 +28,15 @@ export class VFileMessage extends Error {
    * @returns
    *   Instance of `VFileMessage`.
    */
-  // To do: next major: expose `undefined` everywhere instead of `null`.
   constructor(reason, place, origin) {
-    /** @type {[string | null, string | null]} */
-    const parts = [null, null]
+    /** @type {[string | undefined, string | undefined]} */
+    const parts = [undefined, undefined]
     /** @type {Position} */
     let position = {
       // @ts-expect-error: we always follows the structure of `position`.
-      start: {line: null, column: null},
+      start: {line: undefined, column: undefined},
       // @ts-expect-error: "
-      end: {line: null, column: null}
+      end: {line: undefined, column: undefined}
     }
 
     super()
@@ -125,51 +124,51 @@ export class VFileMessage extends Error {
      *
      * * `true` — marks associated file as no longer processable (error)
      * * `false` — necessitates a (potential) change (warning)
-     * * `null | undefined` — for things that might not need changing (info)
+     * * `undefined` — for things that might not need changing (info)
      *
-     * @type {boolean | null | undefined}
+     * @type {boolean | undefined}
      */
     this.fatal
 
     /**
      * Starting line of error.
      *
-     * @type {number | null}
+     * @type {number | undefined}
      */
     this.line = position.start.line
 
     /**
      * Starting column of error.
      *
-     * @type {number | null}
+     * @type {number | undefined}
      */
     this.column = position.start.column
 
     /**
      * Full unist position.
      *
-     * @type {Position | null}
+     * @type {Position | undefined}
      */
     this.position = position
 
     /**
      * Namespace of message (example: `'my-package'`).
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.source = parts[0]
 
     /**
      * Category of message (example: `'my-rule'`).
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.ruleId = parts[1]
 
     /**
      * Path of a file (used throughout the `VFile` ecosystem).
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.file
 
@@ -181,14 +180,14 @@ export class VFileMessage extends Error {
      * Specify the source value that’s being reported, which is deemed
      * incorrect.
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.actual
 
     /**
      * Suggest acceptable values that can be used instead of `actual`.
      *
-     * @type {Array<string> | null}
+     * @type {Array<string> | undefined}
      */
     this.expected
 
@@ -198,14 +197,14 @@ export class VFileMessage extends Error {
      * > 👉 **Note**: this must be an absolute URL that can be passed as `x`
      * > to `new URL(x)`.
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.url
 
     /**
      * Long form description of the message (you should use markdown).
      *
-     * @type {string | null}
+     * @type {string | undefined}
      */
     this.note
     /* eslint-enable no-unused-expressions */
@@ -217,9 +216,9 @@ VFileMessage.prototype.name = ''
 VFileMessage.prototype.reason = ''
 VFileMessage.prototype.message = ''
 VFileMessage.prototype.stack = ''
-VFileMessage.prototype.fatal = null
-VFileMessage.prototype.column = null
-VFileMessage.prototype.line = null
-VFileMessage.prototype.source = null
-VFileMessage.prototype.ruleId = null
-VFileMessage.prototype.position = null
+VFileMessage.prototype.fatal = undefined
+VFileMessage.prototype.column = undefined
+VFileMessage.prototype.line = undefined
+VFileMessage.prototype.source = undefined
+VFileMessage.prototype.ruleId = undefined
+VFileMessage.prototype.position = undefined

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Yields:
   column: 8,
   source: 'spell',
   ruleId: 'typo',
-  position: {start: {line: 1, column: 8}, end: {line: null, column: null}}
+  position: {start: {line: 1, column: 8}, end: {line: undefined, column: undefined}}
 }
 ```
 
@@ -118,23 +118,23 @@ Instance of `VFileMessage`.
 
 *   `reason` (`string`)
     — reason for message (you should use markdown)
-*   `fatal` (`boolean | null | undefined`)
+*   `fatal` (`boolean | undefined`)
     — state of problem; `true` marks associated file as no longer processable
     (error); `false` necessitates a (potential) change (warning);
-    `null | undefined` for things that might not need changing (info)
-*   `line` (`number | null`)
+    `undefined` for things that might not need changing (info)
+*   `line` (`number | undefined`)
     — starting line of error
-*   `column` (`number | null`)
+*   `column` (`number | undefined`)
     — starting column of error
-*   `position` ([`Position | null`][position])
+*   `position` ([`Position | undefined`][position])
     — full unist position
-*   `source` (`string | null`, example: `'my-package'`)
+*   `source` (`string | undefined`, example: `'my-package'`)
     — namespace of message
-*   `ruleId` (`string | null`, example: `'my-rule'`)
+*   `ruleId` (`string | undefined`, example: `'my-rule'`)
     — category of message
-*   `stack` (`string | null`)
+*   `stack` (`string | undefined`)
     — stack of message in code
-*   `file` (`string | null`)
+*   `file` (`string | undefined`)
     — path of a file (used throughout the `VFile` ecosystem)
 
 ### Well-known
@@ -145,14 +145,14 @@ The following fields are documented and typed here.
 
 ###### Fields
 
-*   `actual` (`string | null`)
+*   `actual` (`string`, optional)
     — specify the source value that’s being reported, which is deemed incorrect
-*   `expected` (`Array<string> | null`)
+*   `expected` (`Array<string>`, optional)
     — suggest acceptable values that can be used instead of `actual`
-*   `url` (`string | null`)
+*   `url` (`string`, optional)
     — link to docs for the message (this must be an absolute URL that can be
     passed as `x` to `new URL(x)`)
-*   `note` (`string | null`)
+*   `note` (`string`, optional)
     — long form description of the message (you should use markdown)
 
 ## Types

--- a/test.js
+++ b/test.js
@@ -60,15 +60,15 @@ test('VFileMessage', function () {
   assert.equal(m1.name, '1:1')
   assert.equal(m1.file, '')
   assert.equal(m1.reason, 'Foo')
-  assert.equal(m1.ruleId, null)
-  assert.equal(m1.source, null)
+  assert.equal(m1.ruleId, undefined)
+  assert.equal(m1.source, undefined)
   assert.equal(m1.stack, '')
-  assert.equal(m1.fatal, null)
-  assert.equal(m1.line, null)
-  assert.equal(m1.column, null)
+  assert.equal(m1.fatal, undefined)
+  assert.equal(m1.line, undefined)
+  assert.equal(m1.column, undefined)
   assert.deepEqual(m1.position, {
-    start: {line: null, column: null},
-    end: {line: null, column: null}
+    start: {line: undefined, column: undefined},
+    end: {line: undefined, column: undefined}
   })
 
   assert.equal(
@@ -171,7 +171,7 @@ test('VFileMessage', function () {
     m7.position,
     {
       start: point,
-      end: {line: null, column: null}
+      end: {line: undefined, column: undefined}
     },
     'should accept a position (3)'
   )
@@ -181,7 +181,10 @@ test('VFileMessage', function () {
   assert.deepEqual(
     // @ts-expect-error
     new VFileMessage('test', {}).position,
-    {start: {line: null, column: null}, end: {line: null, column: null}},
+    {
+      start: {line: undefined, column: undefined},
+      end: {line: undefined, column: undefined}
+    },
     'should ignore an empty object'
   )
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/vfile/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/vfile/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/vfile/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Avfile&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This swaps all *output* of `null` with `undefined`. `null` is still allowed as input.

<!--do not edit: pr-->
